### PR TITLE
[MMCA-4104] - Update version & configuration for CDS Financials service - July - V4

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,14 +3,14 @@ import sbt._
 
 object AppDependencies {
 
-  val bootstrapVersion = "7.19.0"
+  private val bootstrapVersion = "7.19.0"
 
-  val compile = Seq(
+  val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "bootstrap-backend-play-28" % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28" % "1.3.0"
   )
 
-  val test = Seq(
+  val test: Seq[ModuleID] = Seq(
     "org.scalatest" %% "scalatest" % "3.2.9" % Test,
     "com.typesafe.play" %% "play-test" % current % Test,
     "com.vladsch.flexmark" % "flexmark-all" % "0.36.8" % "test",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,11 +3,11 @@ import sbt._
 
 object AppDependencies {
 
-  val bootstrapVersion = "7.15.0"
+  val bootstrapVersion = "7.19.0"
 
   val compile = Seq(
     "uk.gov.hmrc" %% "bootstrap-backend-play-28" % bootstrapVersion,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28" % "1.2.0"
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28" % "1.3.0"
   )
 
   val test = Seq(


### PR DESCRIPTION
Description - HMRC library version updates to the latest 

Below libraries have been updated to the latest

uk.gov.hmrc:bootstrap-backend-play-28
uk.gov.hmrc:bootstrap-test-play-28
uk.gov.hmrc.mongo:hmrc-mongo-play-28