### PR TITLE
[MMCA-4675] - Update version, configuration & warnings for CDS Financials service (2.9 to Play 3.0) - V8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ yarn-debug.log
 yarn-error.log
 .metals/
 .vscode/
+.bsp/

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,10 @@
 import scoverage.ScoverageKeys
 import uk.gov.hmrc.DefaultBuildSettings.targetJvm
-import uk.gov.hmrc.DefaultBuildSettings.itSettings
 
 val appName = "customs-financials-session-cache"
 
 val silencerVersion = "1.7.16"
-val bootstrapVersion = "8.5.0"
+val bootstrapVersion = "8.6.0"
 val scala2_13_12 = "2.13.12"
 
 ThisBuild / majorVersion := 0
@@ -23,9 +22,6 @@ lazy val it = project
   .enablePlugins(PlayScala)
   .dependsOn(microservice % "test->test")
   .settings(libraryDependencies ++= Seq("uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion % Test))
-
-ThisBuild / majorVersion := 0
-ThisBuild / scalaVersion := scala2_13_12
 
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,22 +1,18 @@
-import play.core.PlayVersion.current
 import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "8.5.0"
+  private val bootstrapVersion = "8.6.0"
+  private val mongoVersion = "1.9.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
     "uk.gov.hmrc" %% "bootstrap-backend-play-30" % bootstrapVersion,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30" % "1.8.0"
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30" % mongoVersion
   )
 
   val test: Seq[ModuleID] = Seq(
-    "org.scalatest" %% "scalatest" % "3.2.16" % Test,
-    "com.typesafe.play" %% "play-test" % "2.9.2" % Test,
-    "com.vladsch.flexmark" % "flexmark-all" % "0.64.8" % "test",
-    "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % "test",
-    "org.mockito" %% "mockito-scala-scalatest" % "1.17.29" % "test",
+    "org.mockito" %% "mockito-scala-scalatest" % "1.17.31" % "test",
     "uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion % "test"
   )
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -12,7 +12,7 @@ object AppDependencies {
   )
 
   val test: Seq[ModuleID] = Seq(
-    "org.mockito" %% "mockito-scala-scalatest" % "1.17.31" % "test",
-    "uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion % "test"
+    "org.mockito" %% "mockito-scala-scalatest" % "1.17.31" % Test,
+    "uk.gov.hmrc" %% "bootstrap-test-play-30" % bootstrapVersion % Test
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,9 @@ resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.21.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.2")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.3")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0"
   exclude("org.scala-lang.modules", "scala-xml_2.12"))


### PR DESCRIPTION
Description - Upgrade to Play 3.0 and related lib updates.

Below have been done as part of this PR

- Update to play 3.0
- Update other lib to updated versions
- add .bsp folder in .gitignore
- minor refactoring