### PR TITLE
[MMCA-5055] - remove targetJvm for Java 21 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import scoverage.ScoverageKeys
-import uk.gov.hmrc.DefaultBuildSettings.targetJvm
 
 val appName = "customs-financials-session-cache"
 
@@ -26,7 +25,6 @@ lazy val it = project
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
   .settings(
-    targetJvm := "jvm-11",
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
 
     libraryDependencies ++= Seq(


### PR DESCRIPTION
- [x] Services will need to be on Play 2.9 or 3.0 and using sbt 1.9.7, Scala 2.13.12 to use it.
- [x] Remove `targetJvm` in build.sbt
- [x] Check that the service runs locally on Java 21 first.
- [x] Update microservice job builders in build-jobs to opt in to Java 21.
- [x] Ensure build passes with Java 21.